### PR TITLE
Convert imports and exports to ES6 syntax

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
                     noImplicitAny: true
                 },
                 src: ['src/**/*.ts'],
-                dest: 'build/'
+                dest: 'build/src'
             },
             tests: {
                 options: {

--- a/benchmarks/message.bench.ts
+++ b/benchmarks/message.bench.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/baseline.d.ts" />
 
-import MessageHelper = require("../tests/messageHelper");
-import Message = require("../src/message");
+import MessageHelper from "../tests/messageHelper";
+import Message from "../src/message";
 
 suite("Message", () => {
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   ],
   "main": "lib/index.js",
+  "typings": "lib/hl7parser.d.ts",
   "scripts": {
     "test": "grunt"
   },
@@ -30,9 +31,8 @@
     "grunt-dts-concat": "^0.1.10",
     "grunt-mocha-test": "^0.12.2",
     "grunt-ts-clean": "^0.2.0",
-    "grunt-typescript": "0.6.1",
-    "mocha": "^2.0.1",
-    "typescript": "1.4.1"
+    "grunt-typescript": "0.8.0",
+    "mocha": "^2.0.1"
   },
   "tonicExampleFilename": "example.js",
   "keywords": [

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,10 +1,10 @@
-import Node = require('./node');
-import Delimiters = require("./delimiters");
-import ValueNode = require("./valueNode");
-import SubComponent = require("./subComponent");
-import NodeBase = require('./nodeBase');
+import Node from './node';
+import Delimiters from "./delimiters";
+import ValueNode from "./valueNode";
+import SubComponent from "./subComponent";
+import NodeBase from './nodeBase';
 
-class Component extends ValueNode {
+export default class Component extends ValueNode {
 
     constructor(parent: NodeBase, key: string, text: string) {
         super(parent, key, text, Delimiters.SubComponent);
@@ -25,5 +25,3 @@ class Component extends ValueNode {
         return new SubComponent(this, (index + 1).toString(), text);
     }
 }
-
-export = Component;

--- a/src/delimiters.ts
+++ b/src/delimiters.ts
@@ -1,5 +1,4 @@
-declare const enum Delimiters {
-
+enum Delimiters {
     Segment,
     Field,
     Component,
@@ -8,4 +7,4 @@ declare const enum Delimiters {
     SubComponent
 }
 
-export = Delimiters;
+export default Delimiters;

--- a/src/emptyNode.ts
+++ b/src/emptyNode.ts
@@ -1,6 +1,6 @@
-import Node = require("./node");
+import Node from "./node";
 
-class EmptyNode implements Node {
+export default class EmptyNode implements Node {
 
     get name(): string {
         return null;
@@ -70,5 +70,3 @@ class EmptyNode implements Node {
         throw new Error("Not implemented");
     }
 }
-
-export = EmptyNode;

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,10 +1,10 @@
-import Node = require('./node');
-import Delimiters = require("./delimiters");
-import ValueNode = require("./valueNode");
-import FieldRepetition = require("./fieldRepetition");
-import NodeBase = require('./nodeBase');
+import Node from './node';
+import Delimiters from "./delimiters";
+import ValueNode from "./valueNode";
+import FieldRepetition from "./fieldRepetition";
+import NodeBase from './nodeBase';
 
-class Field extends ValueNode {
+export default class Field extends ValueNode {
 
     constructor(parent: NodeBase, key: string, text: string) {
         super(parent, key, text, Delimiters.Repetition);
@@ -45,5 +45,3 @@ class Field extends ValueNode {
         return child;
     }
 }
-
-export = Field;

--- a/src/fieldRepetition.ts
+++ b/src/fieldRepetition.ts
@@ -1,10 +1,10 @@
-import Node = require('./node');
-import Delimiters = require("./delimiters");
-import ValueNode = require("./valueNode");
-import Component = require("./component");
-import NodeBase = require('./nodeBase');
+import Node from './node';
+import Delimiters from "./delimiters";
+import ValueNode from "./valueNode";
+import Component from "./component";
+import NodeBase from './nodeBase';
 
-class FieldRepetition extends ValueNode {
+export default class FieldRepetition extends ValueNode {
 
     constructor(parent: NodeBase, key: string, text: string) {
         super(parent, key, text, Delimiters.Component);
@@ -31,5 +31,3 @@ class FieldRepetition extends ValueNode {
         return new Component(this, (index + 1).toString(), text);
     }
 }
-
-export = FieldRepetition;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import MessageImpl = require("./message");
+import MessageImpl from "./message";
 
 /**
  * An HL7 message.

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,11 +1,11 @@
-import Node = require("./node");
-import NodeBase = require('./nodeBase');
-import Delimiters = require("./delimiters");
-import SegmentList = require("./segmentList");
-import Segment = require("./segment");
-import Util = require("./util");
+import Node from "./node";
+import NodeBase from './nodeBase';
+import Delimiters from "./delimiters";
+import SegmentList from "./segmentList";
+import Segment from "./segment";
+import * as Util from "./util";
 
-class Message extends NodeBase {
+export default class Message extends NodeBase {
 
     private _delimiters: string;
     private _matchUnescape: RegExp;
@@ -219,5 +219,3 @@ class Message extends NodeBase {
         }
     }
 }
-
-export = Message;

--- a/src/node.ts
+++ b/src/node.ts
@@ -23,4 +23,4 @@ interface Node {
     path: string[];
 }
 
-export = Node;
+export default Node;

--- a/src/nodeBase.ts
+++ b/src/nodeBase.ts
@@ -1,10 +1,10 @@
-import Delimiters = require("./delimiters");
-import Message = require("./message");
-import Node = require("./node");
-import EmptyNode = require("./emptyNode");
-import Util = require("./util");
+import Delimiters from "./delimiters";
+import Message from "./message";
+import Node from "./node";
+import EmptyNode from "./emptyNode";
+import * as Util from "./util";
 
-class NodeBase implements Node {
+export default class NodeBase implements Node {
 
     protected parent: NodeBase;
 
@@ -203,7 +203,7 @@ class NodeBase implements Node {
     protected get message(): Message {
 
         if(this._message) return this._message;
-        return this._message = this.parent ? this.parent.message : <Message>this;
+        return this._message = this.parent ? this.parent.message : <any>this;
     }
 
     read(path: string[]): Node {
@@ -356,5 +356,3 @@ class NodeBase implements Node {
         return date.getFullYear().toString() + Util.pad(date.getMonth() + 1, 2) + Util.pad(date.getDate(), 2);
     }
 }
-
-export = NodeBase;

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,10 +1,10 @@
-import Node = require("./node");
-import NodeBase = require('./nodeBase');
-import Delimiters = require("./delimiters");
-import Field = require("./field");
-import SubComponent = require("./subComponent");
+import Node from "./node";
+import NodeBase from './nodeBase';
+import Delimiters from "./delimiters";
+import Field from "./field";
+import SubComponent from "./subComponent";
 
-class Segment extends NodeBase {
+export default class Segment extends NodeBase {
 
     private _segmentName: string;
 
@@ -70,5 +70,3 @@ class Segment extends NodeBase {
         return new Field(this, index.toString(), text);
     }
 }
-
-export = Segment;

--- a/src/segmentList.ts
+++ b/src/segmentList.ts
@@ -1,8 +1,8 @@
-import Node = require("./node");
-import NodeBase = require('./nodeBase');
-import Segment = require("./segment");
+import Node from "./node";
+import NodeBase from './nodeBase';
+import Segment from "./segment";
 
-class SegmentList extends NodeBase {
+export default class SegmentList extends NodeBase {
 
     private _segments: Segment[];
 
@@ -39,5 +39,3 @@ class SegmentList extends NodeBase {
         return this._segments;
     }
 }
-
-export = SegmentList;

--- a/src/subComponent.ts
+++ b/src/subComponent.ts
@@ -1,9 +1,9 @@
-import Node = require('./node');
-import Delimiters = require("./delimiters");
-import ValueNode = require("./valueNode");
-import NodeBase = require('./nodeBase');
+import Node from './node';
+import Delimiters from "./delimiters";
+import ValueNode from "./valueNode";
+import NodeBase from './nodeBase';
 
-class SubComponent extends ValueNode {
+export default class SubComponent extends ValueNode {
 
     constructor(parent: NodeBase, key: string, text: string) {
         super(parent, key, text);
@@ -17,5 +17,3 @@ class SubComponent extends ValueNode {
         return !this.toString();
     }
 }
-
-export = SubComponent;

--- a/src/valueNode.ts
+++ b/src/valueNode.ts
@@ -1,8 +1,8 @@
-import Node = require("./node");
-import NodeBase = require('./nodeBase');
-import Delimiters = require("./delimiters");
+import Node from "./node";
+import NodeBase from './nodeBase';
+import Delimiters from "./delimiters";
 
-class ValueNode extends NodeBase {
+export default class ValueNode extends NodeBase {
 
     protected key: string;
 
@@ -65,5 +65,3 @@ class ValueNode extends NodeBase {
         return this.parent.path.concat([this.key]);
     }
 }
-
-export = ValueNode;

--- a/tests/message.tests.ts
+++ b/tests/message.tests.ts
@@ -1,12 +1,11 @@
 /// <reference path="../typings/mocha.d.ts"/>
 /// <reference path="../typings/chai.d.ts"/>
 
-import chai = require("chai");
-import assert = chai.assert;
-import Message = require("../src/message");
-import Segment = require("../src/segment");
-import EmptyNode = require("../src/emptyNode");
-import MessageHelper = require("./messageHelper");
+import { assert } from "chai";
+import Message from "../src/message";
+import Segment from "../src/segment";
+import EmptyNode from "../src/emptyNode";
+import * as MessageHelper from "./messageHelper";
 
 describe('Message', () => {
 

--- a/tests/messageHelper.ts
+++ b/tests/messageHelper.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/node.d.ts"/>
 
-import fs = require("fs");
-import Message = require("../src/message");
+import * as fs from "fs";
+import Message from "../src/message";
 
 export function createSiuS12Message(): Message {
     return createHl7Message("SIU_S12");

--- a/tests/valueNode.tests.ts
+++ b/tests/valueNode.tests.ts
@@ -1,13 +1,12 @@
 /// <reference path="../typings/mocha.d.ts"/>
 /// <reference path="../typings/chai.d.ts"/>
 
-import chai = require("chai");
-import assert = chai.assert;
-import Message = require("../src/message");
-import ValueNode = require("../src/valueNode");
-import Segment = require("../src/segment");
-import EmptyNode = require("../src/emptyNode");
-import MessageHelper = require("./messageHelper");
+import { assert } from "chai";
+import Message from "../src/message";
+import ValueNode from "../src/valueNode";
+import Segment from "../src/segment";
+import EmptyNode from "../src/emptyNode";
+import * as MessageHelper from "./messageHelper";
 
 describe('ValueNode', () => {
     describe('toString()', () => {

--- a/typings/chai.d.ts
+++ b/typings/chai.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module chai {
+declare module "chai" {
     export class AssertionError {
         constructor(message: string, _props?: any, ssf?: Function);
         name: string;
@@ -277,8 +277,4 @@ declare module chai {
 
         ifError(val: any, msg?: string):void;
     }
-}
-
-declare module "chai" {
-    export = chai;
 }


### PR DESCRIPTION
Thanks for your work on this library. My company has been using it for a while and recently some combination of updates to webpack and typescript have resulted this library now causing the error seen in webpack/webpack#4039. This PR would convert imports into the new ES6 style. It still generates a CommonJS module, so it should be backwards compatible. I had to make some minor upgrades to typescript to allow the new import style. Please let me know if you have any problems with these changes. If you do not planning on maintaining this library to be compatible with future Typescript/Webpack releases that would also be good to know.